### PR TITLE
Update for latest Rust and Cargo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ watch.sh
 /examples/**
 !/examples/*.rs
 !/examples/assets/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,10 @@ version = "0.0.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "indiv0 <contact@nikitapek.in>",
-    "mitchmindtree <me@michellnordine.com>"]
+    "mitchmindtree <me@michellnordine.com>"
+]
 
-[[lib]]
+[lib]
 
 name = "dsp"
 path = "./src/lib.rs"
@@ -20,8 +21,3 @@ git = "https://github.com/jeremyletang/rust-portaudio"
 
 name = "test"
 path = "./src/test.rs"
-
-[dependencies.rust-dsp]
-
-git = "https://github.com/mitchmindtree/rust-dsp"
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,10 @@ extern crate portaudio;
 extern crate time;
 extern crate serialize;
 
-pub use Node = node::Node;
-pub use NodeData = node::Data;
-pub use SoundStream = sound_stream::SoundStream;
-pub use SoundStreamSettings = sound_stream_settings::SoundStreamSettings;
+pub use node::Node as Node;
+pub use node::Data as NodeData;
+pub use sound_stream::SoundStream as SoundStream;
+pub use sound_stream_settings::SoundStreamSettings as SoundStreamSettings;
 
 pub mod macros;
 
@@ -19,4 +19,3 @@ mod node;
 mod port_audio_back_end;
 mod sound_stream;
 mod sound_stream_settings;
-

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,14 +1,15 @@
-
 //! Test app for rust-dsp.
 //!
 //! This file will normally be in a strange state;
 //! it's really just a testing ground for the new
 //! features as I add them. I'll get around to making
 //! some proper examples soon!
-//! 
+//!
 
 #![feature(phase)]
 #[phase(plugin, link)] extern crate dsp;
+
+use std::time::duration::Duration;
 
 use dsp::{
     SoundStream,
@@ -142,7 +143,7 @@ fn main() {
         let mut soundstream = SoundApp::new(receiver, settings);
         soundstream.run(settings);
     });
-    std::io::timer::sleep(3000);
+    std::io::timer::sleep(Duration::seconds(3));
     sender.send(true);
 }
 


### PR DESCRIPTION
Add `Cargo.lock` to `.gitignore`, update to latest Cargo.toml format, remove `mitchmindtree/rust-dsp` as a Cargo dep, update to latest Rust.
