### PR TITLE
Added methods for removing all inputs or outputs from a given node, closes #97

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "dsp-chain"
-version = "0.4.3"
+version = "0.4.4"
 authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
     "bvssvni <bvssvni@gmail.com>",

--- a/examples/graph.rs
+++ b/examples/graph.rs
@@ -47,7 +47,7 @@ fn main() {
 
     // If adding a connection between two nodes would create a cycle, Graph will return an Err.
     if let Err(err) = dsp_graph.add_input(synth, oscillator_a) {
-        println!("{:?}", ::std::error::Error::description(&err));
+        println!("Test for error: {:?}", ::std::error::Error::description(&err));
     }
 
     // Set the synth as the master node for the graph.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,13 @@ pub use graph::{
     Graph,
     NodeIndex,
     Inputs,
+    InputsWithIndices,
     InputsMut,
+    InputsMutWithIndices,
     Outputs,
+    OutputsWithIndices,
     OutputsMut,
+    OutputsMutWithIndices,
     WouldCycle,
 };
 pub use node::Node;


### PR DESCRIPTION
Also added index iterator adaptor for Inputs and Outputs iterators, `.with_indices()`.