### PR TITLE
Use duplex::Event instead of Event from sound_stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,13 +42,13 @@ pub use graph::{
 pub use node::Node;
 pub use sound_stream::{
     Amplitude,
-    Event,
     PaSample,
     Sample,
     Settings,
     SoundStream,
     Wave
 };
+pub use sound_stream::duplex::Event;
 pub use sound_stream::Error as SoundStreamError;
 
 mod dsp;


### PR DESCRIPTION
This fixes lib.rs, which is currently broken, but this isn't a complete fix as the examples are also broken (hence why the Travis CI build failed). I'd fix them myself but I'm unsure what changes need to be made.