### PR TITLE
Vastly simplify the graph module by using petgraph's Dfs and moving buffers from nodes to edges.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "dsp-chain"
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
     "bvssvni <bvssvni@gmail.com>",

--- a/examples/synth.rs
+++ b/examples/synth.rs
@@ -71,6 +71,7 @@ fn main() {
 }
 
 /// Our type for which we will implement the `Dsp` trait.
+#[derive(Debug)]
 enum DspNode {
     /// Synth will be our demonstration of a master GraphNode.
     Synth,


### PR DESCRIPTION
A call to our `Graph`'s audio_requested method should now involve no allocations whatsoever (unless for some strange reason buffer sizes don't match the output, which shouldn't happen).