### PR TITLE
Indexed Inputs and connection per Input Index

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -303,7 +303,14 @@ where
         dest: NodeIndex,
     ) -> Result<EdgeIndex, WouldCycle> {
         self.dag
-            .add_edge(src, dest, Connection { buffer: Vec::new(), in_port: 0})
+            .add_edge(
+                src,
+                dest,
+                Connection {
+                    buffer: Vec::new(),
+                    in_port: 0,
+                },
+            )
             .map(|edge| {
                 self.prepare_visit_order();
                 edge
@@ -320,7 +327,14 @@ where
         dest: NodeIndex,
     ) -> Result<EdgeIndex, WouldCycle> {
         self.dag
-            .add_edge(src, dest, Connection { buffer: Vec::new(), in_port: src_id})
+            .add_edge(
+                src,
+                dest,
+                Connection {
+                    buffer: Vec::new(),
+                    in_port: src_id,
+                },
+            )
             .map(|edge| {
                 self.prepare_visit_order();
                 edge
@@ -352,7 +366,10 @@ where
         I: ::std::iter::IntoIterator<Item = (NodeIndex, NodeIndex)>,
     {
         fn new_connection<F>() -> Connection<F> {
-            Connection { buffer: Vec::new(), in_port: 0}
+            Connection {
+                buffer: Vec::new(),
+                in_port: 0,
+            }
         }
         self.dag
             .add_edges(connections.into_iter().map(|(src, dest)| {
@@ -423,7 +440,10 @@ where
     pub fn add_input(&mut self, src: N, dest: NodeIndex) -> (EdgeIndex, NodeIndex) {
         let indices = self.dag.add_parent(
             dest,
-            Connection { buffer: Vec::new(), in_port: 0},
+            Connection {
+                buffer: Vec::new(),
+                in_port: 0,
+            },
             src,
         );
         self.prepare_visit_order();
@@ -446,7 +466,10 @@ where
     pub fn add_output(&mut self, src: NodeIndex, dest: N) -> (EdgeIndex, NodeIndex) {
         let indices = self.dag.add_child(
             src,
-            Connection { buffer: Vec::new(), in_port: 0},
+            Connection {
+                buffer: Vec::new(),
+                in_port: 0,
+            },
             dest,
         );
         self.prepare_visit_order();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -579,6 +579,7 @@ where
             // Walk over each of the input connections to sum their buffers to the output.
             let mut inputs = self.inputs(node_idx);
             while let Some(connection_idx) = inputs.next_edge(self) {
+                let connection = &self[connection_idx];
 
                 // Sum the connection's buffer onto the output.
                 //

--- a/src/node.rs
+++ b/src/node.rs
@@ -19,21 +19,24 @@ where
     /// additional argument `other_inputs`.
     /// This are additional inputs that can be used if the Node accepts those.
     /// There is a default implementation that can be overriden.
-    fn audio_requested_by_id(&mut self, buffer: &mut [F], other_inputs: HashMap<usize, Box<[F]>>, sample_hz: f64) {
+    fn audio_requested_by_id(
+        &mut self,
+        buffer: &mut [F],
+        other_inputs: HashMap<usize, Box<[F]>>,
+        sample_hz: f64,
+    ) {
         if other_inputs.len() > 0 {
             for input in other_inputs {
                 if input.0 == 0 {
-                sample::slice::zip_map_in_place(
-                    buffer,
-                    &input.1,
-                    |this_frame, other_frame| {
+                    sample::slice::zip_map_in_place(buffer, &input.1, |this_frame, other_frame| {
                         this_frame.zip_map(other_frame, |this_sample, other_sample| {
-                            let this_signed = this_sample.to_sample::<<F::Sample as Sample>::Signed>();
-                            let other_signed = other_sample.to_sample::<<F::Sample as Sample>::Signed>();
+                            let this_signed = this_sample
+                                .to_sample::<<F::Sample as Sample>::Signed>();
+                            let other_signed = other_sample
+                                .to_sample::<<F::Sample as Sample>::Signed>();
                             (this_signed + other_signed).to_sample::<F::Sample>()
                         })
-                    },
-                );
+                    });
                 }
             }
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,5 +1,6 @@
 use {Frame, Sample};
 use sample;
+use std::collections::HashMap;
 
 /// Types to be used as a **Node** within the DSP **Graph**.
 pub trait Node<F>
@@ -18,7 +19,7 @@ where
     /// additional argument `other_inputs`.
     /// This are additional inputs that can be used if the Node accepts those.
     /// There is a default implementation that can be overriden.
-    fn audio_requested_by_id(&mut self, buffer: &mut [F], other_inputs: &[(usize, Box<[F]>)], sample_hz: f64) {
+    fn audio_requested_by_id(&mut self, buffer: &mut [F], other_inputs: HashMap<usize, Box<[F]>>, sample_hz: f64) {
         if other_inputs.len() > 0 {
             for input in other_inputs {
                 if input.0 == 0 {

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,5 @@
 use {Frame, Sample};
+use sample;
 
 /// Types to be used as a **Node** within the DSP **Graph**.
 pub trait Node<F>
@@ -12,6 +13,31 @@ where
     /// Any source/generator type nodes should simply render straight to the buffer.
     /// Any effects/processor type nodes should mutate the buffer directly.
     fn audio_requested(&mut self, buffer: &mut [F], sample_hz: f64);
+
+    /// Requests audio from the **Node** like the `audio_requested` method but it has one
+    /// additional argument `other_inputs`.
+    /// This are additional inputs that can be used if the Node accepts those.
+    /// There is a default implementation that can be overriden.
+    fn audio_requested_by_id(&mut self, buffer: &mut [F], other_inputs: &[(usize, Box<[F]>)], sample_hz: f64) {
+        if other_inputs.len() > 0 {
+            for input in other_inputs {
+                if input.0 == 0 {
+                sample::slice::zip_map_in_place(
+                    buffer,
+                    &input.1,
+                    |this_frame, other_frame| {
+                        this_frame.zip_map(other_frame, |this_sample, other_sample| {
+                            let this_signed = this_sample.to_sample::<<F::Sample as Sample>::Signed>();
+                            let other_signed = other_sample.to_sample::<<F::Sample as Sample>::Signed>();
+                            (this_signed + other_signed).to_sample::<F::Sample>()
+                        })
+                    },
+                );
+                }
+            }
+        }
+        self.audio_requested(buffer, sample_hz);
+    }
 
     /// Following the call to the `Node`'s `audio_requested` method, the `Graph` will sum together
     /// some of the original (dry) signal with some of the processed (wet) signal.


### PR DESCRIPTION
Add new method `audio_requested_by_id(&mut self, buffer: &mut [F], other_inputs: HashMap<usize, Box<F>>, sample_hz: f64)` for the `Node` trait with default implementation.
This Method can be implemented so that a Node can accept input from more than one input.
The Method `add_connection_by_id(&mut self, src: NodeIndex, src_id: usize, dest: NodeIndex) -> Result<EdgeIndex, WouldCycle>` can be used to connect two Nodes and specify the input id form the destination node.