### PR TITLE
Update 'sample' to 0.10.0 and use 'dyn' keyword

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "./src/lib.rs"
 
 [dependencies]
 daggy = "0.4.0"
-sample = "0.6.0"
+sample = "0.10.0"
 
 [dev-dependencies]
 portaudio = "0.6.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use graph::{
 };
 pub use node::Node;
 pub use sample::{
-    self, conv, rate, signal, slice, Duplex as DuplexSample, Frame, FromSample, Sample, Signal, ToSample,
+    self, conv, interpolate, signal, slice, Duplex as DuplexSample, Frame, FromSample, Sample, Signal, ToSample,
 };
 
 mod graph;

--- a/src/node.rs
+++ b/src/node.rs
@@ -48,7 +48,7 @@ where
     }
 }
 
-impl<F> Node<F> for Box<Node<F>>
+impl<F> Node<F> for Box<dyn Node<F>>
 where
     F: Frame,
 {


### PR DESCRIPTION
Update the `sample` dependency from `0.6.0` to `0.10.0` and use the new `dyn` keyword since raw trait objects are deprecated. Note that this is a breaking change, since `sample::rate` has been renamed to `sample::interpolate`.