### PR TITLE
Use daggy's StableDag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "dsp"
 path = "./src/lib.rs"
 
 [dependencies]
-daggy = "0.4.0"
+daggy = { git = "https://github.com/mitchmindtree/daggy", rev = "bcb36c7b", features = ["stable_dag"] }
 sample = "0.10.0"
 
 [dev-dependencies]

--- a/examples/synth.rs
+++ b/examples/synth.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), pa::Error> {
 
         // Traverse inputs or outputs of a node with the following pattern.
         let mut inputs = graph.inputs(synth);
-        while let Some(input_idx) = inputs.next_node(&graph) {
+        while let Some((_, input_idx)) = inputs.walk_next(&graph) {
             if let DspNode::Oscillator(_, ref mut pitch, _) = graph[input_idx] {
                 // Pitch down our oscillators for fun.
                 *pitch -= 0.1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,10 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
-pub use daggy::{self, Walker};
+pub use daggy::stabledag;
 pub use graph::{
-    Connection, Dag, EdgeIndex, Graph, Inputs, NodeIndex, NodesMut, Outputs, PetGraph, RawEdges,
-    RawNodes, VisitOrder, VisitOrderReverse, WouldCycle,
+    Connection, Dag, EdgeIndex, Graph, Inputs, NodeIndex, NodesMut, Outputs, PetGraph,
+    VisitOrder, VisitOrderReverse, WouldCycle, Walker,
 };
 pub use node::Node;
 pub use sample::{


### PR DESCRIPTION
Using `StableDag` should fix the [index-shifting behavior](https://github.com/RustAudio/dsp-chain/issues/103), which previously occurred when nodes were removed from the graph.

There are a few API-breaking changes with this solution, however:
* `raw_nodes` is replaced by `node_references`
* `raw_edges` is replaced by `edge_references`
* `Walker`'s `next_node` and `next_edge` are replaced by `walk_next` (as defined by the upstream API)